### PR TITLE
avoid missing slash issue

### DIFF
--- a/app/code/community/VladimirPopov/WebForms/Block/Webforms.php
+++ b/app/code/community/VladimirPopov/WebForms/Block/Webforms.php
@@ -306,8 +306,8 @@ class VladimirPopov_WebForms_Block_Webforms
     {
         if ($this->isAjax()) {
             $secure = strstr(Mage::helper('core/url')->getCurrentUrl(), 'https://') ? true : false;
-            // avoid trailing slash issue
-            return $this->getUrl('', array('_secure' => $secure)) . 'webforms/index/iframe';
+            // avoid trailing slash and missing slash issue
+            return rtrim($this->getUrl('webforms/index/iframe', array('_secure' => $secure)), '/');
         }
         return Mage::helper('core/url')->getCurrentUrl();
     }


### PR DESCRIPTION
in form when using ajax methodology no slash between domain and the route of the request handlers with original code

![image](https://user-images.githubusercontent.com/17334804/70615901-2e92ac80-1c05-11ea-8671-8a355b47e8e5.png)
